### PR TITLE
Rework matrix printing functions

### DIFF
--- a/packages/koehnlab/print_utilities/__init__.py
+++ b/packages/koehnlab/print_utilities/__init__.py
@@ -1,4 +1,5 @@
 from .print_matrix import (
+    printMat,
     printMatC,
     printMatF,
 )

--- a/packages/koehnlab/print_utilities/print_matrix.py
+++ b/packages/koehnlab/print_utilities/print_matrix.py
@@ -1,7 +1,121 @@
 # a few convenient output routines
 
+from typing import Optional, Type, Any
 
-def printMatC(mat, formatstr="7.2f", maxcol=10, put_labels=True, triangle=False):
+import math
+import numpy as np
+
+
+def getFormatWidth(fmt: str) -> int:
+    """Gets the field width of formatting a number with the given formatting string"""
+    return len(fmt.format(1))
+
+
+def printMat(
+    matrix,
+    entryFmt: Optional[str] = None,
+    colsPerLine: int = 10,
+    useLabels: bool = True,
+    triangle: bool = False,
+    dtype: Optional[Type[Any]] = None,
+) -> None:
+    """Print the entries of the given matrix (or vector) in a easily readable format
+    matrix      --  Matrix or vector to print
+    entryFmt    -- A custom format string to use for formatting the matrix entries
+    colsPerLine -- The maximum amount of columns displayed on a single line (will wrap, if needed)
+    useLabels   -- Whether rows and columns should be labeled explicitly
+    triangle    -- Only output the (lower) triangle of the matrix
+    dtype       -- The type as which to print the matrix entries (only has effect if not entryFmt is provided)
+    """
+
+    # Check matrix dimensions
+    nRows = len(matrix)
+    try:
+        nColumns = len(matrix[0]) if nRows > 0 else 0
+    except TypeError:
+        # column vector -> transform to 1-column matrix to make it indexable by two indices
+        nColumns = 1
+        newMatrix = []
+        for entry in matrix:
+            newMatrix.append([entry])
+        matrix = newMatrix
+
+    if nRows == 0 and nColumns == 0:
+        return
+
+    # Determine the data type of the matrix entries
+    if not dtype:
+        try:
+            # For numpy objects, we use the provided member
+            dtype = matrix.dtype  # type: ignore
+        except:
+            # Otherwise, we assume that all entries have the same type and deduce the type
+            # from the first entry (defaulting to float if there are no entries)
+            dtype = type(matrix[0][0]) if nRows > 1 and nColumns > 1 else float
+
+    # Choose appropriate format for the matrix entries
+    if entryFmt is None:
+        if np.issubdtype(dtype, int):
+            # We use a float format to allow printing floats as integers
+            entryFmt = "{: 5.0f}"
+        elif np.issubdtype(dtype, complex):
+            entryFmt = "{0.real: 7.2f} {0.imag:< 7.2f}"
+        else:
+            entryFmt = "{: 12.6f}"
+    elif not "{" in entryFmt:
+        entryFmt = "{:" + entryFmt + "}"
+
+    colBatches = math.ceil(nColumns / colsPerLine)
+
+    entryWidth = getFormatWidth(entryFmt)
+    rowLabelWidth = math.ceil(math.log10(nRows) + 1e-6)
+
+    colLabelFmt = "{:^" + str(entryWidth) + "d}"
+    rowLabelFmt = "{:" + str(rowLabelWidth) + "d}"
+
+    # Do the actual printing (in batches, in case the matrix has more columns that colsPerLine
+    for batchNum in range(colBatches):
+        # Correct for column batching (line wrapping)
+        colOffset = batchNum * colsPerLine
+        nColsInBatch = min(colsPerLine, nColumns - colOffset)
+
+        # Handle printing only the lower triangle of the matrix
+        nPrintRows = nRows - batchNum * colsPerLine if triangle else nRows
+        assert nPrintRows > 0
+        startRow = nRows - nPrintRows
+        assert startRow >= 0
+
+        if useLabels:
+            # Print column labels
+            print((" " * (rowLabelWidth + 1)) + "|", end="")
+            for col in range(nColsInBatch):
+                print(colLabelFmt.format(batchNum * colsPerLine + col + 1), end="|")
+            print()
+
+        for row in range(startRow, startRow + nPrintRows):
+            # Handle printing only the lower triangle of the matrix
+            nPrintCols = (
+                min(row + 1 - startRow, nColsInBatch) if triangle else nColsInBatch
+            )
+
+            if useLabels:
+                # Start row with row label
+                print(rowLabelFmt.format(row + 1), end="  ")
+
+            for col in range(nPrintCols):
+                print(entryFmt.format(matrix[row][col + colOffset]), end=" ")
+
+            print()
+        print()
+
+
+def printMatC(
+    mat,
+    formatstr: Optional[str] = None,
+    maxcol: int = 10,
+    put_labels: bool = True,
+    triangle: bool = False,
+) -> None:
     """Print a matrix of complex values
     mat        --  a matrix (as exception also a vector is accepted)
     formatstr  -- format the real and imaginary part using this format (valid python format required)
@@ -9,42 +123,23 @@ def printMatC(mat, formatstr="7.2f", maxcol=10, put_labels=True, triangle=False)
     put_labels -- output the labels for rows and columns
     triangle   -- only output the (lower) triangle
     """
-
-    d1 = mat.shape[0]
-    try:
-        d2 = mat.shape[1]
-    except:
-        d2 = 1
-    fmt = " {:" + formatstr + "}{:" + formatstr + "}  "
-    spc = formatstr.split(".")[0]
-    fmtspc = " {:" + spc + "}{:" + spc + "}  "
-    bst = 0
-    bnd = min(maxcol, d2)
-    while bst < d2:
-        if put_labels:
-            print("{:5}".format(""), end="")
-            for jj in range(bst, bnd):
-                print(fmtspc.format(jj, " "), end="")
-            print("")
-        for ii in range(d1):
-            if not triangle or ii >= bst:
-                if put_labels:
-                    print("{:5}".format(ii), end="")
-                bnd2 = bnd
-                if triangle:
-                    bnd2 = min(bnd, ii + 1)
-                for jj in range(bst, bnd2):
-                    try:
-                        print(fmt.format(mat[ii, jj].real, mat[ii, jj].imag), end="")
-                    except:
-                        print(fmt.format(mat[ii].real, mat[ii].imag), end="")
-                print("")
-        bst = bnd
-        bnd = min(bst + maxcol, d2)
-        print("")
+    printMat(
+        matrix=mat,
+        entryFmt="{:" + formatstr + "}" if formatstr else None,
+        colsPerLine=maxcol,
+        useLabels=put_labels,
+        triangle=triangle,
+        dtype=complex,
+    )
 
 
-def printMatF(mat, formatstr="12.6f", maxcol=10, put_labels=True, triangle=False):
+def printMatF(
+    mat,
+    formatstr: Optional[str] = None,
+    maxcol: int = 10,
+    put_labels: bool = True,
+    triangle: bool = False,
+) -> None:
     """Print a matrix of float values
     mat        --  a matrix (as exception also a vector is accepted)
     formatstr  -- format the real and imaginary part using this format (valid python format required)
@@ -52,36 +147,11 @@ def printMatF(mat, formatstr="12.6f", maxcol=10, put_labels=True, triangle=False
     put_labels -- output the labels for rows and columns
     triangle   -- only output the (lower) triangle
     """
-
-    d1 = mat.shape[0]
-    try:
-        d2 = mat.shape[1]
-    except:
-        d2 = 1
-    fmt = " {:" + formatstr + "}  "
-    spc = formatstr.split(".")[0]
-    fmtspc = " {:" + spc + "}  "
-    bst = 0
-    bnd = min(maxcol, d2)
-    while bst < d2:
-        if put_labels:
-            print("{:5}".format(""), end="")
-            for jj in range(bst, bnd):
-                print(fmtspc.format(jj), end="")
-            print("")
-        for ii in range(d1):
-            if not triangle or ii >= bst:
-                if put_labels:
-                    print("{:5}".format(ii), end="")
-                bnd2 = bnd
-                if triangle:
-                    bnd2 = min(bnd, ii + 1)
-                for jj in range(bst, bnd2):
-                    try:
-                        print(fmt.format(mat[ii, jj]), end="")
-                    except:
-                        print(fmt.format(mat[ii]), end="")
-                print("")
-        bst = bnd
-        bnd = min(bst + maxcol, d2)
-        print("")
+    printMat(
+        matrix=mat,
+        entryFmt="{:" + formatstr + "}" if formatstr else None,
+        colsPerLine=maxcol,
+        useLabels=put_labels,
+        triangle=triangle,
+        dtype=float,
+    )


### PR DESCRIPTION
Instead of having two separate (almost identical) implementations for floating point and complex values, we now have a single unified implementation that also allows printing values as integers and also supports non-Numpy matrices and vectors (which I think were unsupported with the old implementations)