### PR TITLE
Switch sign convention for Zeeman term (to the actual one)

### DIFF
--- a/packages/koehnlab/spin_hamiltonians/spin_utils.py
+++ b/packages/koehnlab/spin_hamiltonians/spin_utils.py
@@ -81,7 +81,8 @@ def diagonalizeSpinHamiltonian(Hmat, Mmat=None, Bfield=None):
 
     if Mmat is not None and Bfield is not None:
         for ii in range(3):
-            HmatD += Bfield[ii] * Mmat[ii] * muBcm
+            # H_Zeeman = - M B
+            HmatD -= Bfield[ii] * Mmat[ii] * muBcm
 
     En, U = np.linalg.eigh(HmatD)
 

--- a/tests/test_spin_hamiltonians.py
+++ b/tests/test_spin_hamiltonians.py
@@ -79,7 +79,8 @@ class TestFiniteDifference(unittest.TestCase):
             ],
             dtype=complex,
         )
-        MmatX = np.array(
+        # M = - muB g S  --> therefore we add a -1 here
+        MmatX = -np.array(
             [
                 [0.0, sq3, 0.0, 0.0],
                 [sq3, 0.0, 2.0, 0.0],
@@ -89,7 +90,7 @@ class TestFiniteDifference(unittest.TestCase):
             dtype=complex,
         )
         MmatY = (
-            np.array(
+            -np.array(
                 [
                     [0.0, -sq3, 0.0, 0.0],
                     [sq3, 0.0, -2.0, 0.0],
@@ -100,7 +101,7 @@ class TestFiniteDifference(unittest.TestCase):
             )
             * 1j
         )
-        MmatZ = np.diag([3.0, 1.0, -1.0, -3.0])
+        MmatZ = -np.diag([3.0, 1.0, -1.0, -3.0])
 
         ev1, U = diagonalizeSpinHamiltonian(Hmat)
         assert_array_almost_equal(
@@ -112,7 +113,7 @@ class TestFiniteDifference(unittest.TestCase):
         self.assertAlmostEqual(np.abs(MZT[1, 1]), 2.97565832)
         self.assertAlmostEqual(np.abs(MZT[2, 2]), 0.97565832)
         self.assertAlmostEqual(np.abs(MZT[3, 3]), 0.97565832)
-        self.assertAlmostEqual(MZT[0, 2], -0.31108551)
+        self.assertAlmostEqual(MZT[0, 2], 0.31108551)
 
         # test with Zeeman terms:
         ev2, _ = diagonalizeSpinHamiltonian(


### PR DESCRIPTION
In previous script versions, the magnetic moments due to the pseudo-spin were missing a sign, which was compensated by the missing sign in the previous definition of the Zeeman term. But actually:

  M = - g S   (where S is a pseudospin operator, M and S are vectorial) and
  H_Zeeman = - M.B     (B is the magn. field and "." the scalar product)

Scripts using diagonalizeSpinHamiltonian() must be updated!