### PR TITLE
Fix ordering convention for Kramers pairs in diagonalizer

### DIFF
--- a/packages/koehnlab/spin_hamiltonians/spin_utils.py
+++ b/packages/koehnlab/spin_hamiltonians/spin_utils.py
@@ -81,7 +81,8 @@ def diagonalizeSpinHamiltonian(Hmat, Mmat=None, Bfield=None):
 
     if Mmat is not None and Bfield is not None:
         for ii in range(3):
-            HmatD += Bfield[ii] * Mmat[ii] * muBcm
+            # H_Zeeman = - M B
+            HmatD -= Bfield[ii] * Mmat[ii] * muBcm
 
     En, U = np.linalg.eigh(HmatD)
 

--- a/packages/koehnlab/spin_hamiltonians/spin_utils.py
+++ b/packages/koehnlab/spin_hamiltonians/spin_utils.py
@@ -101,7 +101,8 @@ def diagonalizeSpinHamiltonian(Hmat, Mmat=None, Bfield=None):
                 ndim_block += 1
             idxnd = idxst + ndim_block
             # print("current block: ",idxst,idxnd-1)
-            submat = np.array(Mtraf[idxst:idxnd, idxst:idxnd])
+            # use negative submat to get positive Mu first
+            submat = -np.array(Mtraf[idxst:idxnd, idxst:idxnd])
             # printMatC(submat)
             # print()
             # diagonalize submatrix

--- a/tests/test_spin_hamiltonians.py
+++ b/tests/test_spin_hamiltonians.py
@@ -79,7 +79,8 @@ class TestFiniteDifference(unittest.TestCase):
             ],
             dtype=complex,
         )
-        MmatX = np.array(
+        # M = - muB g S  --> therefore we add a -1 here
+        MmatX = -np.array(
             [
                 [0.0, sq3, 0.0, 0.0],
                 [sq3, 0.0, 2.0, 0.0],
@@ -89,7 +90,7 @@ class TestFiniteDifference(unittest.TestCase):
             dtype=complex,
         )
         MmatY = (
-            np.array(
+            -np.array(
                 [
                     [0.0, -sq3, 0.0, 0.0],
                     [sq3, 0.0, -2.0, 0.0],
@@ -100,7 +101,7 @@ class TestFiniteDifference(unittest.TestCase):
             )
             * 1j
         )
-        MmatZ = np.diag([3.0, 1.0, -1.0, -3.0])
+        MmatZ = -np.diag([3.0, 1.0, -1.0, -3.0])
 
         ev1, U = diagonalizeSpinHamiltonian(Hmat)
         assert_array_almost_equal(
@@ -112,7 +113,7 @@ class TestFiniteDifference(unittest.TestCase):
         self.assertAlmostEqual(np.abs(MZT[1, 1]), 2.97565832)
         self.assertAlmostEqual(np.abs(MZT[2, 2]), 0.97565832)
         self.assertAlmostEqual(np.abs(MZT[3, 3]), 0.97565832)
-        self.assertAlmostEqual(MZT[0, 2], -0.31108551)
+        self.assertAlmostEqual(MZT[0, 2], 0.31108551)
 
         # test with Zeeman terms:
         ev2, _ = diagonalizeSpinHamiltonian(

--- a/tests/test_spin_hamiltonians.py
+++ b/tests/test_spin_hamiltonians.py
@@ -9,7 +9,7 @@ from numpy.testing import assert_array_almost_equal
 from koehnlab.spin_hamiltonians import spinMat, tprod, diagonalizeSpinHamiltonian
 
 
-class TestFiniteDifference(unittest.TestCase):
+class TestSpinHamiltonians(unittest.TestCase):
     def test_spinMat(self):
         isq2 = np.sqrt(0.5)
         assert_array_almost_equal(
@@ -103,17 +103,17 @@ class TestFiniteDifference(unittest.TestCase):
         )
         MmatZ = -np.diag([3.0, 1.0, -1.0, -3.0])
 
-        ev1, U = diagonalizeSpinHamiltonian(Hmat)
+        ev1, U = diagonalizeSpinHamiltonian(Hmat,np.array([MmatX, MmatY, MmatZ]))
         assert_array_almost_equal(
             ev1, np.array([-248.85528726, -248.85528726, -26.14471274, -26.14471274])
         )
         # test also standard choice of Kramers pair:
         MZT = np.matmul(np.conj(U.T), np.matmul(MmatZ, U))
-        self.assertAlmostEqual(np.abs(MZT[0, 0]), 2.97565832)
-        self.assertAlmostEqual(np.abs(MZT[1, 1]), 2.97565832)
-        self.assertAlmostEqual(np.abs(MZT[2, 2]), 0.97565832)
-        self.assertAlmostEqual(np.abs(MZT[3, 3]), 0.97565832)
-        self.assertAlmostEqual(MZT[0, 2], 0.31108551)
+        self.assertAlmostEqual(MZT[0, 0],  2.97565832)
+        self.assertAlmostEqual(MZT[1, 1], -2.97565832)
+        self.assertAlmostEqual(MZT[2, 2],  0.97565832)
+        self.assertAlmostEqual(MZT[3, 3], -0.97565832)
+        self.assertAlmostEqual(MZT[0, 3],  0.31108551)
 
         # test with Zeeman terms:
         ev2, _ = diagonalizeSpinHamiltonian(


### PR DESCRIPTION
I had to fix the ordering of Kramers pairs such that by default the positive <MZ> comes first. Otherwise the Zeeman scripts start with a wrong ordering, as for positive Bz the state with <MZ> > 0 should become the lowest.

I also adapted the test to check rigorously for this sign convention.